### PR TITLE
Fix compatibility with Django 1.6

### DIFF
--- a/django_dowser/urls.py
+++ b/django_dowser/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:
+    from django.conf.urls.defaults import *
+
 
 urlpatterns = patterns('django_dowser.views',
     url(r'^trace/(?P<typename>[\.\-\w]+)(/(?P<objid>\d+))?$', 'trace'),


### PR DESCRIPTION
Since django.conf.urls.defaults is obsolete in django 1.6, let's use the new module and leave the old import for django < 1.6.
