### PR TITLE
fix absulute urls: use URL reverse

### DIFF
--- a/django_dowser/templates/django_dowser/base.html
+++ b/django_dowser/templates/django_dowser/base.html
@@ -11,7 +11,7 @@
 <body>
 {% block body %}
 <div id="header">
-    <h1><a href="{{home}}">Dowser</a></h1>
+    <h1><a href="{% url 'dowser_index' %}">Dowser</a></h1>
 </div>
 {% endblock body %}
 </body>

--- a/django_dowser/templates/django_dowser/graphs.html
+++ b/django_dowser/templates/django_dowser/graphs.html
@@ -4,7 +4,7 @@
 
 {% block body %}
 <div id="header">
-    <h1><a href="{{home}}">Dowser</a>: Types</h1>
+    <h1><a href="{% url 'dowser_index' %}">Dowser</a>: Types</h1>
 </div>
 
 <div id="output">

--- a/django_dowser/templates/django_dowser/trace.html
+++ b/django_dowser/templates/django_dowser/trace.html
@@ -4,7 +4,7 @@
 
 {% block body %}
 <div id="header">
-    <h1><a href="{{home}}">Dowser</a>: Trace</h1>
+    <h1><a href="{% url 'dowser_index' %}">Dowser</a>: Trace</h1>
 </div>
 
 <h2>{{typename}} {{objid}}</h2>

--- a/django_dowser/templates/django_dowser/tree.html
+++ b/django_dowser/templates/django_dowser/tree.html
@@ -4,7 +4,7 @@
 
 {% block body %}
 <div id="header">
-    <h1><a href="{{home}}">Dowser</a>: Tree</h1>
+    <h1><a href="{% url 'dowser_index' %}">Dowser</a>: Tree</h1>
 </div>
 
 <h2>{{typename}} {{objid}}</h2>

--- a/django_dowser/urls.py
+++ b/django_dowser/urls.py
@@ -5,7 +5,8 @@ except ImportError:
 
 
 urlpatterns = patterns('django_dowser.views',
-    url(r'^trace/(?P<typename>[\.\-\w]+)(/(?P<objid>\d+))?$', 'trace'),
-    url(r'^tree/(?P<typename>[\.\-\w]+)/(?P<objid>\d+)$', 'tree'),
-    url(r'^$', 'index'),
+    url(r'^trace/(?P<typename>[\.\-\w]+)$', 'trace', name='dowser_trace_type'),
+    url(r'^trace/(?P<typename>[\.\-\w]+)/(?P<objid>\d+)$', 'trace', name='dowser_trace_object'),
+    url(r'^tree/(?P<typename>[\.\-\w]+)/(?P<objid>\d+)$', 'tree', name='dowser_tree'),
+    url(r'^$', 'index', name='dowser_index'),
 )

--- a/django_dowser/views.py
+++ b/django_dowser/views.py
@@ -125,6 +125,11 @@ def trace_one(typename, objid):
                 rows = ["<h3>The object you requested is no longer "
                         "of the correct type.</h3>"]
             else:
+                tree = ReferrerTree(obj)
+
+                # repr
+                rows.append("<p class='obj'>%s</p>" % get_repr(obj, 5000))
+
                 # Attributes
                 rows.append('<div class="obj"><h3>Attributes</h3>')
                 for k in dir(obj):
@@ -140,7 +145,6 @@ def trace_one(typename, objid):
                 rows.append('<p class="desc"><a href="%s">Show the '
                             'entire tree</a> of reachable objects</p>'
                             % ("../../tree/%s/%s" % (typename, objid)))
-                tree = ReferrerTree(obj)
                 tree.ignore(all_objs)
                 for depth, parentid, parentrepr in tree.walk(maxdepth=1):
                     if parentid:

--- a/django_dowser/views.py
+++ b/django_dowser/views.py
@@ -2,6 +2,7 @@ from django.template import RequestContext
 from django.shortcuts import render_to_response
 from django.utils.html import escape
 from types import ModuleType, FrameType
+from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import user_passes_test
 import gc
 import sys
@@ -50,7 +51,7 @@ def chart_url(typename,history_slot=0):
 
 
 @user_passes_test(lambda u: u.is_superuser)
-def trace(request,objid,typename):
+def trace(request,typename,objid=None):
 #    typename = req.path_info_pop()
 #    objid = req.path_info_pop()
     gc.collect()
@@ -217,11 +218,14 @@ class ReferrerTree(reftree.Tree):
         key = ""
         if referent:
             key = self.get_refkey(obj, referent)
+        url = reverse('dowser_trace_object', args=(
+            typename,
+            id(obj)
+        ))
         return ('<a class="objectid" href="%s">%s</a> '
                 '<span class="typename">%s</span>%s<br />'
                 '<span class="repr">%s</span>'
-                % (("/dowser/trace/%s/%s" % (typename, id(obj))),
-                   id(obj), prettytype, key, get_repr(obj, 100))
+                % (url, id(obj), prettytype, key, get_repr(obj, 100))
                 )
     
     def get_refkey(self, obj, referent):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
-VERSION = '0.1.3'
+VERSION = '0.1.4'
 
 setup(
 	name="django-dowser",


### PR DESCRIPTION
At first, thanks to this fork of dowser! It really helps me.

This patch fixes issue when installed to other than /dowser/ base URL.

Also, can I ask you please to update package in PyPI? As version in PyPI is too old and doesn't work with current versions of Django.