### PR TITLE
Making the project compatible with Python 3 and newer versions of Django 1.x

### DIFF
--- a/django_dowser/__init__.py
+++ b/django_dowser/__init__.py
@@ -44,9 +44,9 @@ class Dowser(object):
             else:
                 typecounts[typename] = 1
 
-        for typename, count in typecounts.iteritems():
+        for typename, count in typecounts.items():
             if typename not in self.history:
-                self.history[typename] = map(lambda x: deque([0] * x), DOWSER_MAXENTRIES)
+                self.history[typename] = [deque([0] * x) for x in DOWSER_MAXENTRIES]
             self.history[typename][0].appendleft(count)
 
         self.samples[0] += 1
@@ -59,7 +59,7 @@ class Dowser(object):
                 self.samples[i+1] += 1
                 self.samples[i] = 0
 
-        for typename, hist in self.history.iteritems():
+        for typename, hist in self.history.items():
             history = self.history[typename]
             # let's promote max from (set of entries to lower granularity history)
             for i in range(len(self.samples)-1):

--- a/django_dowser/reftree.py
+++ b/django_dowser/reftree.py
@@ -48,7 +48,7 @@ class Tree(object):
         """Walk the object tree, pretty-printing each branch."""
         self.ignore_caller()
         for depth, refid, rep in self.walk(maxresults, maxdepth):
-            print ("%9d" % refid), (" " * depth * 2), rep
+            print(("%9d" % refid), (" " * depth * 2), rep)
 
 
 def _repr_container(obj):
@@ -174,9 +174,9 @@ class CircularReferents(Tree):
         """Walk the object tree, pretty-printing each branch."""
         self.ignore_caller()
         for trail in self.walk(maxresults, maxdepth):
-            print trail
+            print(trail)
         if self.stops:
-            print "%s paths stopped because max depth reached" % self.stops
+            print("%s paths stopped because max depth reached" % self.stops)
 
 
 def count_objects():
@@ -184,6 +184,5 @@ def count_objects():
     for obj in gc.get_objects():
         objtype = type(obj)
         d[objtype] = d.get(objtype, 0) + 1
-    d = [(v, k) for k, v in d.iteritems()]
-    d.sort()
+    d = sorted((v, k) for k, v in d.items())
     return d


### PR DESCRIPTION
I tested these changes with a project that's using Django 1.11 and Python 3.6, and it works fine. Furthermore, the changes should be compatible with Python 2.7 as well - although I'm using the plain `iter()` method at some places, which on Python 2.7 creates a new list of tuples. If you want me to mandatorily use an iterator, let me know and I can use `six` to get it (or implement a custom function for this if you prefer).